### PR TITLE
add `netcore` directory to `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 tsconfig.json
 src
+netcore


### PR DESCRIPTION
No need to ship this directory, and `Newtonsoft.Json` in the `.csproj` file is triggering some vulnerability scanners.