### PR TITLE
Upgrade to the latest version of Newtonsoft.Json (12.0.3->13.0.2)

### DIFF
--- a/netcore/testar.csproj
+++ b/netcore/testar.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
[@azure-tools/cadl-csharp](https://www.npmjs.com/package/%40azure-tools%2Fcadl-csharp) project is using the `json-serialize-refs` which depends on old version of Newtonsoft.Json that has critical security vulnerabilities.

See details below: 

```
[INFO] _________________________________________________________________________________________________________________________________________________ 
[INFO] |Security Alerts                                                                                                                                | 
[INFO] |_______________________________________________________________________________________________________________________________________________| 
[INFO] |Alert title                             |Affected component                      |Severity                      |Due date                      | 
[INFO] |________________________________________|________________________________________|______________________________|______________________________| 
[INFO] |GHSA-5crp-9r3c-p9vr                     |Newtonsoft.Json 12.0.3                  |High                          |2022-07-29T21:14:31.3718047Z  | 
[INFO] |________________________________________|________________________________________|______________________________|______________________________| 
[INFO]  
[INFO] To change the severity threshold or build result, either dismiss the alerts in Component Governance or update the settings of this build task. 
[INFO] Please contact OpenSourceEngSupport@microsoft.com with questions. 
##[error]1 security alert(s) need resolution. High and critical security vulnerabilities found by Component Governance must be resolved before their Due Date.

```